### PR TITLE
Fixed typo in Maven repository url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
     }
 
     maven {
-        url "http://repo.mavenRepo.apache.org/mavenRepo2"
+        url "http://repo.maven.apache.org/maven2"
     }
 }
 


### PR DESCRIPTION
Fixed typo in Maven repository url in build.gradle
